### PR TITLE
Update MD5.cs

### DIFF
--- a/Md5.WP7/MD5.cs
+++ b/Md5.WP7/MD5.cs
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography
             working[cbSize] = 0x80;
 
             //We have enough room to store the length in this chunk
-            if (cbSize <= 56)
+            if (cbSize < 56)
             {
                 Array.Copy(length, 0, working, 56, 8);
                 GetHashBlock(working, ref ABCD, 0);


### PR DESCRIPTION
Fixed known comparison bug. Which causes strings longer than 55 chars to return bad hashes. Please remeber to put fixed version to NuGet.
